### PR TITLE
SAG-142: Implement soft delete for menu by ID

### DIFF
--- a/backend/MenuAndStatisticsManagementService_Django/menu_management/urls.py
+++ b/backend/MenuAndStatisticsManagementService_Django/menu_management/urls.py
@@ -3,5 +3,5 @@ from .views import MenuViewSet
 
 urlpatterns = [
     path('menus', MenuViewSet.as_view({'get': 'list','post':'create','delete':'delete_many' })),
-    path('menus/<str:pk>', MenuViewSet.as_view({'get': 'get_by_id', 'put': 'update_by_id', 'delete': 'delete'})),
+    path('menus/<str:pk>', MenuViewSet.as_view({'get': 'get_by_id', 'put': 'update_by_id', 'delete': 'delete_by_id'})),
 ]


### PR DESCRIPTION
- Added `delete_by_id` method to mark a menu as 'DELETED' instead of actual removal.
- Implemented logging to track deletion attempts.
- Included API documentation using `@extend_schema` for better OpenAPI documentation.
- Handled cases where the menu is already deleted, returning an appropriate response.
- Updated `modified_time` when a menu is marked as deleted.