### PR TITLE
SAG-145: Add timestamp to all API responses

### DIFF
--- a/backend/MenuAndStatisticsManagementService_Django/MenuAndStatisticsManagementService_Django/settings.py
+++ b/backend/MenuAndStatisticsManagementService_Django/MenuAndStatisticsManagementService_Django/settings.py
@@ -111,6 +111,7 @@ MIDDLEWARE = [
     
     # Thêm middleware bắt lỗi toàn cục
     'MenuAndStatisticsManagementService_Django.middlewares.GlobalExceptionMiddleware',
+    'MenuAndStatisticsManagementService_Django.middlewares.AppendTimestampMiddleware',
 ]
 
 


### PR DESCRIPTION
- Implemented `AppendTimestampMiddleware` to automatically append a timestamp to all JSON responses.
- Ensured compatibility with Django Rest Framework by marking the response for re-rendering.
- Updated `MIDDLEWARE` settings to include the new middleware.